### PR TITLE
Add Chess Pieces Dataset

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -492,6 +492,7 @@ Collection of papers, datasets, code and other resources for object detection an
 - [LOST : Longterm Observation of Scenes with Tracks](http://lost.cse.wustl.edu/) [top down and street level viewpoint] [no ground truth]
 - [JTA](http://imagelab.ing.unimore.it/imagelab/page.asp?IdPage=25) [top down and street level viewpoint] [synthetic/GTA 5] [pedestrian] [3D annotations]
 - [PathTrack: Fast Trajectory Annotation with Path Supervision](http://people.ee.ethz.ch/~daid/pathtrack/) [top down and street level viewpoint] [iccv17] [pedestrian] 
+- [Chess Pieces](https://public.roboflow.ai/object-detection/chess-full) [45° side angle]
  
 <a id="single_object_tracking__1"></a>
 ## Single Object Tracking


### PR DESCRIPTION
Hi, we published an object detection dataset of Chess Pieces (labeled with bounding boxes; some examples with a single piece and some with multiple) as public domain. Was hoping to get it included on the list.